### PR TITLE
Update to bundler 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # OpenStudio Extension Gem
 
+## Version 0.2.0
+
+* Upgrade Bundler to 2.1.x
+* Remove json_pure gem
+* TODO: Update measure tester to 0.2.0 (removes need for github checkout)
+
 ## Version 0.1.5 (Unreleased)
 
 ## Version 0.1.4

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 //Jenkins pipelines are stored in shared libaries. Please see: https://github.com/tijcolem/nrel_cbci_jenkins_libs 
  
-@Library('cbci_shared_libs@develop') _
+@Library('cbci_shared_libs') _
 
 // Build for PR to develop branch only. 
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) { // check if set

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,6 @@
 // Build for PR to develop branch only. 
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) { // check if set
 
-  openstudio_extension_gems()
+  openstudio_extension_gems_3_x()
     
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 //Jenkins pipelines are stored in shared libaries. Please see: https://github.com/tijcolem/nrel_cbci_jenkins_libs 
  
-@Library('cbci_shared_libs') _
+@Library('cbci_shared_libs@develop') _
 
 // Build for PR to develop branch only. 
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) { // check if set

--- a/lib/openstudio/extension/version.rb
+++ b/lib/openstudio/extension/version.rb
@@ -35,6 +35,6 @@
 
 module OpenStudio
   module Extension
-    VERSION = '0.1.4'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '~> 2.5.5'
 
   spec.add_dependency 'bundler', '~> 2.1'
   spec.add_dependency 'openstudio-workflow', '~> 1.3.4'

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'openstudio-extension'
   spec.version       = OpenStudio::Extension::VERSION
   spec.platform      = Gem::Platform::RUBY
-  spec.authors       = ['Katherine Fleming', 'Nicholas Long', 'Dan Macumber']
+  spec.authors       = ['Katherine Fleming', 'Nicholas Long', 'Daniel Macumber']
   spec.email         = ['katherine.fleming@nrel.gov', 'nicholas.long@nrel.gov', 'daniel.macumber@nrel.gov']
 
   spec.homepage      = 'https://openstudio.net'
@@ -18,16 +18,15 @@ Gem::Specification.new do |spec|
       #'documentation_uri' =>  'https://www.rubydoc.info/gems/openstudio-extension-gem/#{gem.version}',
       'source_code_uri' => "https://github.com/NREL/openstudio-extension-gem/tree/v#{spec.version}"
   }
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir = 'exe'
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.5.1'
+  spec.required_ruby_version = '~> 2.5.0'
 
   spec.add_dependency 'bundler', '~> 2.1'
   spec.add_dependency 'openstudio-workflow', '~> 1.3.4'

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -5,14 +5,19 @@ require 'openstudio/extension/version'
 Gem::Specification.new do |spec|
   spec.name          = 'openstudio-extension'
   spec.version       = OpenStudio::Extension::VERSION
+  spec.platform      = Gem::Platform::RUBY
   spec.authors       = ['Katherine Fleming', 'Nicholas Long', 'Dan Macumber']
   spec.email         = ['katherine.fleming@nrel.gov', 'nicholas.long@nrel.gov', 'daniel.macumber@nrel.gov']
-  spec.platform      = Gem::Platform::RUBY
 
+  spec.homepage      = 'https://openstudio.net'
   spec.summary       = 'openstudio base gem for creating generic extensions with encapsulated data and measures.'
   spec.description   = 'openstudio base gem for creating generic extensions with encapsulated data and measures.'
-  spec.homepage      = 'https://openstudio.net'
-
+  spec.metadata = {
+    bug_tracker_uri: 'https://github.com/NREL/openstudio-extension-gem/issues',
+    changelog_uri: 'https://github.com/NREL/openstudio-extension-gem/blob/develop/CHANGELOG.md',
+    #documentation_uri: 'https://www.rubydoc.info/gems/openstudio-extension-gem/#{gem.version}',
+    source_code_uri: "https://github.com/NREL/openstudio-extension-gem/tree/v#{spec.version}"
+  }
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path(__dir__)) do
@@ -22,7 +27,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bundler', '~> 2.0'
+  spec.required_ruby_version = '>= 2.5'
+
+  spec.add_dependency 'bundler', '~> 2.1'
   spec.add_dependency 'json_pure', '2.2.0'
   spec.add_dependency 'openstudio-workflow', '~> 1.3.4'
   spec.add_dependency 'openstudio_measure_tester', '~> 0.1.7'

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.5.5'
+  spec.required_ruby_version = '~> 2.5.1'
 
   spec.add_dependency 'bundler', '~> 2.1'
   spec.add_dependency 'openstudio-workflow', '~> 1.3.4'

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -13,10 +13,10 @@ Gem::Specification.new do |spec|
   spec.summary       = 'openstudio base gem for creating generic extensions with encapsulated data and measures.'
   spec.description   = 'openstudio base gem for creating generic extensions with encapsulated data and measures.'
   spec.metadata = {
-    bug_tracker_uri: 'https://github.com/NREL/openstudio-extension-gem/issues',
-    changelog_uri: 'https://github.com/NREL/openstudio-extension-gem/blob/develop/CHANGELOG.md',
-    #documentation_uri: 'https://www.rubydoc.info/gems/openstudio-extension-gem/#{gem.version}',
-    source_code_uri: "https://github.com/NREL/openstudio-extension-gem/tree/v#{spec.version}"
+      'bug_tracker_uri' => 'https://github.com/NREL/openstudio-extension-gem/issues',
+      'changelog_uri' => 'https://github.com/NREL/openstudio-extension-gem/blob/develop/CHANGELOG.md',
+      #'documentation_uri' =>  'https://www.rubydoc.info/gems/openstudio-extension-gem/#{gem.version}',
+      'source_code_uri' => "https://github.com/NREL/openstudio-extension-gem/tree/v#{spec.version}"
   }
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -35,8 +35,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'openstudio_measure_tester', '~> 0.1.7'
   spec.add_dependency 'parallel', '~> 1.12.0'
 
+  spec.add_development_dependency 'github_api', '~> 0.18.0'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'rubocop', '~> 0.54.0'
-  spec.add_development_dependency "github_api", "~> 0.18.0"
 end

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bundler', '~> 1.9'
+  spec.add_dependency 'bundler', '~> 2.0'
   spec.add_dependency 'json_pure', '2.2.0'
   spec.add_dependency 'openstudio-workflow', '~> 1.3.4'
   spec.add_dependency 'openstudio_measure_tester', '~> 0.1.7'

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5'
 
   spec.add_dependency 'bundler', '~> 2.1'
-  spec.add_dependency 'json_pure', '2.2.0'
   spec.add_dependency 'openstudio-workflow', '~> 1.3.4'
   spec.add_dependency 'openstudio_measure_tester', '~> 0.1.7'
   spec.add_dependency 'parallel', '~> 1.12.0'


### PR DESCRIPTION
Perhaps this should be a `add_development_dependency` instead so it's not blocking...?

Cf https://github.com/NREL/openstudio-gems/pull/10