### PR TITLE
Support economizer modeling when create_typical measure is split into two parts

### DIFF
--- a/lib/openstudio/extension/core/os_lib_model_generation.rb
+++ b/lib/openstudio/extension/core/os_lib_model_generation.rb
@@ -2804,16 +2804,25 @@ module OsLib_ModelGeneration
       end
     end
 
-    # TODO: - when add methods below add bool to enable/disable them with default value to true
-
-    # add daylight controls, need to perform a sizing run for 2010
-    if args['template'] == '90.1-2010'
-      if standard.model_run_sizing_run(model, "#{Dir.pwd}/SRvt") == false
-        log_messages_to_runner(runner, debug = true)
-        return false
-      end
+    # add_daylighting_controls (since outdated measure don't have this default to true if arg not found)
+    if !args.has_key('add_daylighting_controls')
+      args['add_daylighting_controls'] = true
     end
+    if args['add_daylighting_controls']
+      # remove add_daylighting_controls objects
+      if args['remove_objects']
+        model.getDaylightingControls.each(&:remove)
+      end
+
+      # add daylight controls, need to perform a sizing run for 2010
+      if args['template'] == '90.1-2010'
+        if standard.model_run_sizing_run(model, "#{Dir.pwd}/SRvt") == false
+          log_messages_to_runner(runner, debug = true)
+          return false
+        end
+      end
     standard.model_add_daylighting_controls(model)
+    end
 
     # add refrigeration
     if args['add_refrigeration']
@@ -3010,7 +3019,7 @@ module OsLib_ModelGeneration
     end
 
     # set hvac controls and efficiencies (this should be last model articulation element)
-    if args['add_hvac']
+if args['add_internal_mass']
       # set additional properties for building
       props = model.getBuilding.additionalProperties
       props.setFeature('hvac_system_type',"#{args['system_type']}")

--- a/lib/openstudio/extension/core/os_lib_model_generation.rb
+++ b/lib/openstudio/extension/core/os_lib_model_generation.rb
@@ -3041,20 +3041,6 @@ module OsLib_ModelGeneration
       end
     end
 
-    # add internal mass
-    if args['add_internal_mass']
-
-      if args['remove_objects']
-        model.getSpaceLoads.each do |instance|
-          next unless instance.to_InternalMass.is_initialized
-          instance.remove
-        end
-      end
-
-      # add internal mass to conditioned spaces; needs to happen after thermostats are applied
-      standard.model_add_internal_mass(model, primary_bldg_type)
-    end
-
     # set unmet hours tolerance
     unmet_hrs_tol_r = args['unmet_hours_tolerance']
     unmet_hrs_tol_k = OpenStudio.convert(unmet_hrs_tol_r, 'R', 'K').get

--- a/lib/openstudio/extension/core/os_lib_model_generation.rb
+++ b/lib/openstudio/extension/core/os_lib_model_generation.rb
@@ -2462,20 +2462,6 @@ module OsLib_ModelGeneration
       end
     end
 
-    # validate climate zone
-    if !args.has_key?('climate_zone') || args['climate_zone'] == 'Lookup From Model'
-      climate_zone = standard.model_get_building_climate_zone_and_building_type(model)['climate_zone']
-      runner.registerInfo("Using climate zone #{climate_zone} from model")
-    else
-      climate_zone = args['climate_zone']
-      runner.registerInfo("Using climate zone #{climate_zone} from user arguments")
-    end
-    if climate_zone == ''
-      runner.registerError("Could not determine climate zone from measure arguments or model.")
-      return false
-    end
-
-
     # validate fraction parking
     fraction = OsLib_HelperMethods.checkDoubleAndIntegerArguments(runner, user_arguments, 'min' => 0.0, 'max' => 1.0, 'min_eq_bool' => true, 'max_eq_bool' => true, 'arg_array' => ['onsite_parking_fraction'])
     if !fraction then return false end
@@ -2573,6 +2559,19 @@ module OsLib_ModelGeneration
 
     # Make the standard applier
     standard = Standard.build((args['template']).to_s)
+
+    # validate climate zone
+    if !args.has_key?('climate_zone') || args['climate_zone'] == 'Lookup From Model'
+      climate_zone = standard.model_get_building_climate_zone_and_building_type(model)['climate_zone']
+      runner.registerInfo("Using climate zone #{climate_zone} from model")
+    else
+      climate_zone = args['climate_zone']
+      runner.registerInfo("Using climate zone #{climate_zone} from user arguments")
+    end
+    if climate_zone == ''
+      runner.registerError("Could not determine climate zone from measure arguments or model.")
+      return false
+    end
 
     # make sure daylight savings is turned on up prior to any sizing runs being done.
     if args['enable_dst']
@@ -2805,7 +2804,7 @@ module OsLib_ModelGeneration
     end
 
     # add_daylighting_controls (since outdated measure don't have this default to true if arg not found)
-    if !args.has_key('add_daylighting_controls')
+    if !args.has_key?('add_daylighting_controls')
       args['add_daylighting_controls'] = true
     end
     if args['add_daylighting_controls']

--- a/lib/openstudio/extension/core/os_lib_model_generation.rb
+++ b/lib/openstudio/extension/core/os_lib_model_generation.rb
@@ -2462,6 +2462,20 @@ module OsLib_ModelGeneration
       end
     end
 
+    # validate climate zone
+    if !args.has_key?('climate_zone') || args['climate_zone'] == 'Lookup From Model'
+      climate_zone = standard.model_get_building_climate_zone_and_building_type(model)['climate_zone']
+      runner.registerInfo("Using climate zone #{climate_zone} from model")
+    else
+      climate_zone = args['climate_zone']
+      runner.registerInfo("Using climate zone #{climate_zone} from user arguments")
+    end
+    if climate_zone == ''
+      runner.registerError("Could not determine climate zone from measure arguments or model.")
+      return false
+    end
+
+
     # validate fraction parking
     fraction = OsLib_HelperMethods.checkDoubleAndIntegerArguments(runner, user_arguments, 'min' => 0.0, 'max' => 1.0, 'min_eq_bool' => true, 'max_eq_bool' => true, 'arg_array' => ['onsite_parking_fraction'])
     if !fraction then return false end
@@ -2645,13 +2659,6 @@ module OsLib_ModelGeneration
         is_residential = 'Yes'
       else
         is_residential = 'No'
-      end
-      if !args.has_key?('climate_zone') || args['climate_zone'] == 'Lookup From Model'
-        climate_zone = standard.model_get_building_climate_zone_and_building_type(model)['climate_zone']
-        runner.registerInfo("Using climate zone #{climate_zone} from model")
-      else
-        climate_zone = args['climate_zone']
-        runner.registerInfo("Using climate zone #{climate_zone} from user arguments")
       end
       bldg_def_const_set = standard.model_add_construction_set(model, climate_zone, lookup_building_type, nil, is_residential)
       if bldg_def_const_set.is_initialized

--- a/lib/openstudio/extension/core/os_lib_model_generation.rb
+++ b/lib/openstudio/extension/core/os_lib_model_generation.rb
@@ -3019,7 +3019,7 @@ module OsLib_ModelGeneration
     end
 
     # set hvac controls and efficiencies (this should be last model articulation element)
-if args['add_internal_mass']
+    if args['add_hvac']
       # set additional properties for building
       props = model.getBuilding.additionalProperties
       props.setFeature('hvac_system_type',"#{args['system_type']}")


### PR DESCRIPTION
@nllong and @kflemin This fixes economizer modeling when create_typical measure is split into two parts. I have tested the measure tests for create_typical measure using this branch installed on my system ruby. I have not been able to test using the OpenStudio CLI even when changing gem version to be newer and using `--include` or `--gem_path` in the command. 