### PR TITLE
3 1 0 upgrade & workflow gem bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # OpenStudio Extension Gem
 
-## Version 0.2.X (unreleased)
+## Version 0.2.6 (unreleased)
 
 * remove the os_lib_reporting.rb helpers. This file is only used for OS reporting measure and should not be shared with other users.
+* Upgrade dependency to openstudio-workflow gem to `~> 2.1.0`
 
 ## Version 0.2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # OpenStudio Extension Gem
 
-## Version 0.2.6 (unreleased)
+## Version 0.3.0
 
 * remove the os_lib_reporting.rb helpers. This file is only used for OS reporting measure and should not be shared with other users.
 * Upgrade dependency to openstudio-workflow gem to `~> 2.1.0`
+* This version works only with EnergyPlus 9.4 since it depends on OpenStudio workflow `~> 2.1.0`
 
 ## Version 0.2.5
 

--- a/lib/openstudio/extension/runner.rb
+++ b/lib/openstudio/extension/runner.rb
@@ -77,16 +77,16 @@ module OpenStudio
           # use the default values overriden with runner.conf values
           @options = @options.merge(runner_config.options)
         end
-        
+
         # use the passed values or defaults overriden by passed options
         @options = @options.merge(options)
-       
+
         puts "Initializing runner with dirname: '#{dirname}' and options: #{@options}"
         @dirname = File.absolute_path(dirname)
-        
+
         # use passed options, otherwise assume @dirname
-        @gemfile_path = (!@options.key?(:gemfile_path) || @options[:gemfile_path] === '') ? File.join(@dirname, 'Gemfile') : @options[:gemfile_path]
-        @bundle_install_path = (!@options.key?(:bundle_install_path) || @options[:bundle_install_path] === '')? File.join(@dirname, '.bundle/install/') : @options[:bundle_install_path]
+        @gemfile_path = !@options.key?(:gemfile_path) || @options[:gemfile_path] === '' ? File.join(@dirname, 'Gemfile') : @options[:gemfile_path]
+        @bundle_install_path = !@options.key?(:bundle_install_path) || @options[:bundle_install_path] === '' ? File.join(@dirname, '.bundle/install/') : @options[:bundle_install_path]
         @original_dir = Dir.pwd
         # puts "DIRNAME: #{@dirname}"
         # puts "@gemfile_path set to: #{@gemfile_path}"

--- a/lib/openstudio/extension/version.rb
+++ b/lib/openstudio/extension/version.rb
@@ -35,6 +35,6 @@
 
 module OpenStudio
   module Extension
-    VERSION = '0.2.5'.freeze
+    VERSION = '0.2.6'.freeze
   end
 end

--- a/lib/openstudio/extension/version.rb
+++ b/lib/openstudio/extension/version.rb
@@ -35,6 +35,6 @@
 
 module OpenStudio
   module Extension
-    VERSION = '0.2.6'.freeze
+    VERSION = '0.3.0'.freeze
   end
 end

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bcl', '~> 0.6.1'
   spec.add_dependency 'bundler', '~> 2.1'
   spec.add_dependency 'octokit', '~> 4.18.0' # for change logs
-  spec.add_dependency 'openstudio-workflow', '~> 2.0.0'
+  spec.add_dependency 'openstudio-workflow', '~> 2.1.0'
   spec.add_dependency 'openstudio_measure_tester', '~> 0.2.3'
   spec.add_dependency 'parallel', '~> 1.19.1'
 


### PR DESCRIPTION
I hijacked this branch from @DavidGoldwasser  (with #79 on it) to bump the version and the workflow version to 2.1.0, so that https://github.com/NREL/openstudio-gems/pull/31 could be built.

