### PR TITLE
Zeroes elevator fraction radiant before setting fraction lost

### DIFF
--- a/lib/openstudio/extension/core/os_lib_model_generation.rb
+++ b/lib/openstudio/extension/core/os_lib_model_generation.rb
@@ -2735,8 +2735,9 @@ module OsLib_ModelGeneration
         elevator_def = elevators.electricEquipmentDefinition
         design_level = elevator_def.designLevel.get
         runner.registerInfo("Adding #{elevators.multiplier.round(1)} elevators each with power of #{OpenStudio.toNeatString(design_level, 0, true)} (W), plus lights and fans.")
-        elevator_def.setFractionLost(1.0)
+        elevator_def.setFractionLatent(0.0)
         elevator_def.setFractionRadiant(0.0)
+        elevator_def.setFractionLost(1.0)
       end
     end
 


### PR DESCRIPTION
Previously, for all elevators, fraction lost was set to 1.0, then fraction radiant was set to 0.0.  However, in OpenStudio 3.1.0, [new error checks](https://github.com/NREL/OpenStudio/blob/develop/src/model/ElectricEquipmentDefinition.cpp#L209-L256) have been added to these OpenStudio setter methods to ensure that the total latent + radiant + lost fraction is below 1.0.  This makes the order that the setters are called in important now.

This change first zeroes-out latent (for good measure) and radiant fractions before setting lost fraction to 1.0 to avoid this error.

This should not change simulation results at all as the final model should be identical to what was previously created.

The reason this fraction lost is set to 1.0 at all is because sometimes in these programmatically-generated models, the elevator can end up in a very small zone, and with the high internal loads of an elevator, this zone can reach unrealistically high temperatures, leading to simulation failures.