### PR TITLE
updates to get rake init_new_gem to work

### DIFF
--- a/init_templates/gemspec.txt
+++ b/init_templates/gemspec.txt
@@ -22,11 +22,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
-  spec.add_development_dependency 'rake', '12.3.1'
-  spec.add_development_dependency 'rspec', '3.7.0'
+  spec.required_ruby_version = '~> 2.5.0'
+
+  spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.9'
   spec.add_development_dependency 'rubocop', '~> 0.54.0'
 
-  spec.add_dependency 'openstudio-extension', '~> 0.1.0'
-  spec.add_dependency 'openstudio-standards', '~> 0.2.7'
+  spec.add_dependency 'openstudio-extension', '~> 0.3.1'
+  spec.add_dependency 'openstudio-standards', '~> 0.2.12'
 end

--- a/init_templates/template_gemfile.txt
+++ b/init_templates/template_gemfile.txt
@@ -16,7 +16,4 @@ elsif allow_local
   gem 'openstudio-extension', github: 'NREL/OpenStudio-extension-gem', branch: 'develop'
 end
 
-gem 'openstudio_measure_tester', '= 0.1.7' # This includes the dependencies for running unit tests, coverage, and rubocop
-
-# simplecov has an unnecessary dependency on native json gem, use fork that does not require this
-gem 'simplecov', github: 'NREL/simplecov'
+gem 'openstudio_measure_tester', '~> 0.2.3' # This includes the dependencies for running unit tests, coverage, and rubocop


### PR DESCRIPTION
Let me know if I should have changed anything else or left anything alone. For example changing version of `simple_cov` instead of removing. I did conform that `bundle install` worked on gem made using `init_new_gem` with this branch on mac.