### PR TITLE
fixes issue #95

### DIFF
--- a/lib/openstudio/extension/core/os_lib_helper_methods.rb
+++ b/lib/openstudio/extension/core/os_lib_helper_methods.rb
@@ -233,7 +233,8 @@ module OsLib_HelperMethods
                 msg.logChannel.include?('runmanager') || # RunManager messages
                 msg.logChannel.include?('setFileExtension') || # .ddy extension unexpected
                 msg.logChannel.include?('Translator') || # Forward translator and geometry translator
-                msg.logMessage.include?('UseWeatherFile') # 'UseWeatherFile' is not yet a supported option for YearDescription
+                msg.logMessage.include?('UseWeatherFile') || # 'UseWeatherFile' is not yet a supported option for YearDescription
+                msg.logMessage.include?('has multiple parents') # 'has multiple parents' is thrown for various types of curves if used in multiple objects
 
         # Report the message in the correct way
         if msg.logLevel == OpenStudio::Info


### PR DESCRIPTION
In the API a curve is a resources so the warnings about multiple parents is invalid and should not prevent a measure from running.