### PR TITLE
update to use 0.2.17 release of standards, bump version to 0.6.0

### DIFF
--- a/lib/openstudio/extension/version.rb
+++ b/lib/openstudio/extension/version.rb
@@ -35,6 +35,6 @@
 
 module OpenStudio
   module Extension
-    VERSION = '0.6.0.rc1'.freeze
+    VERSION = '0.6.0'.freeze
   end
 end

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'openstudio-workflow', '~> 2.3.0'
   spec.add_dependency 'parallel', '~> 1.19.1'
 
-  spec.add_development_dependency 'openstudio-standards', '~> 0.2.17.rc2' # for os_lib unit tests
+  spec.add_development_dependency 'openstudio-standards', '~> 0.2.17' # for os_lib unit tests
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
 end


### PR DESCRIPTION
- Update openstudio-standards to 0.2.17 official 
- Bump version from 0.6.0.r1 to 0.6.0