### PR TITLE
Replace --verbose flag to --loglevel inorder to run CI.

### DIFF
--- a/lib/measures/openstudio_extension_test_measure/resources/os_lib_helper_methods.rb
+++ b/lib/measures/openstudio_extension_test_measure/resources/os_lib_helper_methods.rb
@@ -203,7 +203,8 @@ module OsLib_HelperMethods
                 msg.logChannel.include?('runmanager') || # RunManager messages
                 msg.logChannel.include?('setFileExtension') || # .ddy extension unexpected
                 msg.logChannel.include?('Translator') || # Forward translator and geometry translator
-                msg.logMessage.include?('UseWeatherFile') # 'UseWeatherFile' is not yet a supported option for YearDescription
+                msg.logMessage.include?('UseWeatherFile') || # 'UseWeatherFile' is not yet a supported option for YearDescription
+                msg.logMessage.include?('has multiple parents') # 'has multiple parents' is thrown for various types of curves if used in multiple objects
 
         # Report the message in the correct way
         if msg.logLevel == OpenStudio::Info

--- a/lib/openstudio/extension/runner.rb
+++ b/lib/openstudio/extension/runner.rb
@@ -276,12 +276,12 @@ module OpenStudio
         the_call = ''
         if @gemfile_path
           if @bundle_without_string.empty?
-            the_call = "#{cli} --verbose --bundle '#{@gemfile_path}' --bundle_path '#{@bundle_install_path}' measure -r '#{measures_dir}'"
+            the_call = "#{cli} --loglevel Trace --bundle '#{@gemfile_path}' --bundle_path '#{@bundle_install_path}' measure -r '#{measures_dir}'"
           else
-            the_call = "#{cli} --verbose --bundle '#{@gemfile_path}' --bundle_path '#{@bundle_install_path}' --bundle_without '#{@bundle_without_string}' measure -r '#{measures_dir}'"
+            the_call = "#{cli} --loglevel Trace --bundle '#{@gemfile_path}' --bundle_path '#{@bundle_install_path}' --bundle_without '#{@bundle_without_string}' measure -r '#{measures_dir}'"
           end
         else
-          the_call = "#{cli} --verbose measure -r #{measures_dir}"
+          the_call = "#{cli} --loglevel Trace measure -r #{measures_dir}"
         end
 
         puts 'SYSTEM CALL:'
@@ -316,12 +316,12 @@ module OpenStudio
           the_call = ''
           if @gemfile_path
             if @bundle_without_string.empty?
-              the_call = "#{cli} --verbose --bundle '#{@gemfile_path}' --bundle_path '#{@bundle_install_path}' measure -t '#{m_dir}'"
+              the_call = "#{cli} --loglevel Trace --bundle '#{@gemfile_path}' --bundle_path '#{@bundle_install_path}' measure -t '#{m_dir}'"
             else
-              the_call = "#{cli} --verbose --bundle '#{@gemfile_path}' --bundle_path '#{@bundle_install_path}' --bundle_without '#{@bundle_without_string}' measure -t '#{m_dir}'"
+              the_call = "#{cli} --loglevel Trace --bundle '#{@gemfile_path}' --bundle_path '#{@bundle_install_path}' --bundle_without '#{@bundle_without_string}' measure -t '#{m_dir}'"
             end
           else
-            the_call = "#{cli} --verbose measure -t '#{m_dir}'"
+            the_call = "#{cli} --loglevel Trace measure -t '#{m_dir}'"
           end
 
           puts 'SYSTEM CALL:'
@@ -607,7 +607,7 @@ module OpenStudio
           the_call = ''
           verbose_string = ''
           if @options[:verbose]
-            verbose_string = ' --verbose'
+            verbose_string = '--loglevel Trace'
           end
           if @gemfile_path
             if @bundle_without_string.empty?

--- a/lib/openstudio/extension/runner.rb
+++ b/lib/openstudio/extension/runner.rb
@@ -276,9 +276,15 @@ module OpenStudio
         the_call = ''
         if @gemfile_path
           if @bundle_without_string.empty?
+<<<<<<< Updated upstream
             the_call = "#{cli} --loglevel Trace --bundle '#{@gemfile_path}' --bundle_path '#{@bundle_install_path}' measure -r '#{measures_dir}'"
           else
             the_call = "#{cli} --loglevel Trace --bundle '#{@gemfile_path}' --bundle_path '#{@bundle_install_path}' --bundle_without '#{@bundle_without_string}' measure -r '#{measures_dir}'"
+=======
+            the_call = "#{cli} --verbose --bundle_path '#{@bundle_install_path}' measure -r '#{measures_dir}'"
+          else
+            the_call = "#{cli} --verbose --bundle_path '#{@bundle_install_path}' --bundle_without '#{@bundle_without_string}' measure -r '#{measures_dir}'"
+>>>>>>> Stashed changes
           end
         else
           the_call = "#{cli} --loglevel Trace measure -r #{measures_dir}"
@@ -316,9 +322,15 @@ module OpenStudio
           the_call = ''
           if @gemfile_path
             if @bundle_without_string.empty?
+<<<<<<< Updated upstream
               the_call = "#{cli} --loglevel Trace --bundle '#{@gemfile_path}' --bundle_path '#{@bundle_install_path}' measure -t '#{m_dir}'"
             else
               the_call = "#{cli} --loglevel Trace --bundle '#{@gemfile_path}' --bundle_path '#{@bundle_install_path}' --bundle_without '#{@bundle_without_string}' measure -t '#{m_dir}'"
+=======
+              the_call = "#{cli} --verbose --bundle_path '#{@bundle_install_path}' measure -t '#{m_dir}'"
+            else
+              the_call = "#{cli} --verbose --bundle_path '#{@bundle_install_path}' --bundle_without '#{@bundle_without_string}' measure -t '#{m_dir}'"
+>>>>>>> Stashed changes
             end
           else
             the_call = "#{cli} --loglevel Trace measure -t '#{m_dir}'"
@@ -611,9 +623,9 @@ module OpenStudio
           end
           if @gemfile_path
             if @bundle_without_string.empty?
-              the_call = "#{cli}#{verbose_string} --bundle '#{@gemfile_path}' --bundle_path '#{@bundle_install_path}' run -w '#{run_osw_path}' 2>&1 > \"#{out_log}\""
+              the_call = "#{cli}#{verbose_string} --bundle_path '#{@bundle_install_path}' run -w '#{run_osw_path}' 2>&1 > \"#{out_log}\""
             else
-              the_call = "#{cli}#{verbose_string} --bundle '#{@gemfile_path}' --bundle_path '#{@bundle_install_path}' --bundle_without '#{@bundle_without_string}' run -w '#{run_osw_path}' 2>&1 > \"#{out_log}\""
+              the_call = "#{cli}#{verbose_string} --bundle_path '#{@bundle_install_path}' --bundle_without '#{@bundle_without_string}' run -w '#{run_osw_path}' 2>&1 > \"#{out_log}\""
             end
           else
             the_call = "#{cli}#{verbose_string} run -w '#{run_osw_path}' 2>&1 > \"#{out_log}\""


### PR DESCRIPTION
Since https://github.com/NREL/OpenStudio/pull/4922 . Openstudio doesn't support --verbose anymore.

Replace the --verbose flag to --loglevel Trace to run CI.

Tested this flag locally with `bundle exec rake openstudio:test_with_openstudio`. 