### PR TITLE
Update gemspec to explicitly get  openstudio-standards 050

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # OpenStudio(R) Extension Gem
 
+## Version 0.7.1
+
+* Fixed [#169]( https://github.com/NREL/openstudio-extension-gem/pull/169 ), Replace --verbose flag to --loglevel inorder to run CI.
+* Fixed [#171]( https://github.com/NREL/openstudio-extension-gem/pull/171 ), Remove bundle flag
+* Fixed [#172]( https://github.com/NREL/openstudio-extension-gem/pull/172 ), useless commit, to trigger the CI
+* Fixed [#173]( https://github.com/NREL/openstudio-extension-gem/pull/173 ), Remove bundle flag to run in ci with new commit.
+* Fixed [#174]( https://github.com/NREL/openstudio-extension-gem/pull/174 ), Bump os-standards to 0.5.0
+
 ## Version 0.7.0
 
 * Fixed [#156]( https://github.com/NREL/openstudio-extension-gem/pull/156 ), Adding test for lab building type

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ export RUBYLIB=/Applications/OpenStudio-3.1.0/Ruby
 
 |OpenStudio Extension Gem|OpenStudio|Ruby|
 |:--------------:|:----------:|:--------:|
+| 0.7.1          | 3.7      | 2.7    |
 | 0.7.0          | 3.7      | 2.7    |
 | 0.6.0          | 3.5      | 2.7    |
 | 0.6.0          | 3.5      | 2.7    |

--- a/lib/openstudio/extension/version.rb
+++ b/lib/openstudio/extension/version.rb
@@ -5,6 +5,6 @@
 
 module OpenStudio
   module Extension
-    VERSION = '0.7.0'.freeze
+    VERSION = '0.7.1'.freeze
   end
 end

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'openstudio-workflow', '~> 2.3.0'
   spec.add_dependency 'parallel', '~> 1.19.1'
 
-  spec.add_development_dependency 'openstudio-standards', '>= 0.5.0.rc1', '< 0.6.0' # for os_lib unit tests
+  spec.add_development_dependency 'openstudio-standards', '~> 0.5.0' # for os_lib unit tests
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
 end


### PR DESCRIPTION
0.7.0. is in OpenStudio 3.7.0. At the time of release 0.7.1 isn't included in an OpenStudio installer.