### PR TITLE
Remove hard dependency on ruby 2.7 as we prepare for ruby 3.2.2

### DIFF
--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -26,8 +26,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.7.0'
-
   spec.add_dependency 'bcl', '~> 0.7.1'
   spec.add_dependency 'bundler', '~> 2.1.0'
   spec.add_dependency 'octokit', '~> 4.18.0' # for change logs

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -27,7 +27,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'bcl', '~> 0.7.1'
-  spec.add_dependency 'bundler', '~> 2.1.0'
+  # This only runs on the builders' machine
+  spec.add_dependency 'bundler', '~> 2.1.0' if RUBY_VERSION[0] == "2"
+  spec.add_dependency 'bundler', '~> 2.5.5' if RUBY_VERSION[0] == "3"
   spec.add_dependency 'octokit', '~> 4.18.0' # for change logs
   spec.add_dependency 'openstudio_measure_tester', '~> 0.3.1'
   spec.add_dependency 'openstudio-workflow', '~> 2.3.0'

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bcl', '~> 0.7.1'
+  spec.add_dependency 'bcl', '~> 0.8.0'
   # This only runs on the builders' machine
   spec.add_dependency 'bundler', '~> 2.1.0' if RUBY_VERSION[0] == "2"
   spec.add_dependency 'bundler', '~> 2.5.5' if RUBY_VERSION[0] == "3"


### PR DESCRIPTION
I know this conflicts with #185, still opening it for discussion though.

I also have another commit I chose not to include that's of interest: 4e23ce3c6678f8420d0b5a9db44ea071e18b0573
