### PR TITLE
Don't raise when bundle path mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OpenStudio(R) Extension Gem
 
+## Version 0.8.1
+
+* [#190]( https://github.com/NREL/openstudio-extension-gem/pull/190), Don't raise error when bundle path mismatch occurs
+
 ## Version 0.8.0
 
 * [#184]( https://github.com/NREL/openstudio-extension-gem/pull/184 ), Removing model methods and model method spec tests. Most model methods moved to openstudio-standards-gem, others moved to OpenStudio C++.

--- a/lib/openstudio/extension/runner.rb
+++ b/lib/openstudio/extension/runner.rb
@@ -105,7 +105,7 @@ module OpenStudio
               needs_config = false
 
               if conf_bpath != @bundle_install_path
-                puts "Detected mistmatch between bundle's configured path #{conf_bpath} and runner configuration #{@bundle_install_path}"
+                puts "Detected mismatch between bundle's configured path #{conf_bpath} and runner configuration #{@bundle_install_path}"
                 needs_config = true
               end
 

--- a/lib/openstudio/extension/runner.rb
+++ b/lib/openstudio/extension/runner.rb
@@ -105,7 +105,7 @@ module OpenStudio
               needs_config = false
 
               if conf_bpath != @bundle_install_path
-                raise "Detected mistmatch between bundle's configured path #{conf_bpath} and runner configuration #{@bundle_install_path}"
+                puts "Detected mistmatch between bundle's configured path #{conf_bpath} and runner configuration #{@bundle_install_path}"
                 needs_config = true
               end
 

--- a/lib/openstudio/extension/version.rb
+++ b/lib/openstudio/extension/version.rb
@@ -5,6 +5,6 @@
 
 module OpenStudio
   module Extension
-    VERSION = '0.8.0'.freeze
+    VERSION = '0.8.1'.freeze
   end
 end


### PR DESCRIPTION
* Follow up to #182 

In that PR I made it throw when Detected mistmatch between bundle's configured path and runner.conf
https://github.com/NREL/openstudio-extension-gem/pull/182/files#r1494769490

* @vtnate  reported that in https://github.com/urbanopt/urbanopt-scenario-gem/pull/274 he was getting problems with an urbanot_scenario gem test, that uses a sub bundle...

the repo has ./bundle
the test tries to initiate a new bundle at spec/test/.bundle/install

I suppose the test could just be run in a temporary folder, but it is probably not necessary to throw and force people to do that, and there might be other valid uses where you'd want several bundles.