### PR TITLE
Pinned regexp_parser version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OpenStudio(R) Extension Gem
 
+## Version 0.8.2
+
+* [#192]( https://github.com/NREL/openstudio-extension-gem/pull/192), Pinned regexp_parser version
+
 ## Version 0.8.1
 
 * [#190]( https://github.com/NREL/openstudio-extension-gem/pull/190), Don't raise error when bundle path mismatch occurs

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
-//Jenkins pipelines are stored in shared libaries. Please see: https://github.com/NREL/cbci_jenkins_libs
- 
-@Library('cbci_shared_libs') _
+//Jenkins pipelines are stored in shared libraries. Please see: https://github.com/NREL/cbci_jenkins_libs
 
-// Build for PR to develop branch only. 
+@Library('cbci_shared_libs@develop') _
+
+// Build for PR to develop branch only.
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) { // check if set
 
   openstudio_extension_gems()
-    
+
 }

--- a/lib/openstudio/extension/version.rb
+++ b/lib/openstudio/extension/version.rb
@@ -5,6 +5,6 @@
 
 module OpenStudio
   module Extension
-    VERSION = '0.8.1'.freeze
+    VERSION = '0.8.2'.freeze
   end
 end

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'openstudio_measure_tester', '~> 0.4.0'
   spec.add_dependency 'openstudio-workflow', '~> 2.4.0'
   spec.add_dependency 'parallel', '~> 1.19.1'
-  spec.add_dependency 'regexp_parser', "2.9.0"
+  spec.add_dependency 'regexp_parser', '2.9.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
 end

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'openstudio_measure_tester', '~> 0.4.0'
   spec.add_dependency 'openstudio-workflow', '~> 2.4.0'
   spec.add_dependency 'parallel', '~> 1.19.1'
-
+  spec.add_dependency 'regexp_parser', "2.9.0"
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
 end


### PR DESCRIPTION
This is required to ensure compliance with `rake openstudio:test_with_openstudio`

Solution figured out by @wenyikuang, thank you!