### PR TITLE
Use master branch of Jenkins shared library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 //Jenkins pipelines are stored in shared libraries. Please see: https://github.com/NREL/cbci_jenkins_libs
 
-@Library('cbci_shared_libs@develop') _
+@Library('cbci_shared_libs') _
 
 // Build for PR to develop branch only.
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) { // check if set


### PR DESCRIPTION
We had used develop branch to grab Wenyi's recent fix. That has now been added to `master` branch of the Jenkins config, so we can go back to using that in this repo.