### PR TITLE
Bundler hack to handle conflict with OpenStudio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # OpenStudio(R) Extension Gem
 
+## Version 0.8.3
+* [#199]( https://github.com/NREL/openstudio-extension-gem/pull/199), Patch for bundler conflict issue
+
 ## Version 0.8.2
 
 * [#192]( https://github.com/NREL/openstudio-extension-gem/pull/192), Pinned regexp_parser version

--- a/Rakefile
+++ b/Rakefile
@@ -3,15 +3,20 @@
 # See also https://openstudio.net/license
 # *******************************************************************************
 
-require 'bundler/gem_tasks'
+if !defined?(Bundler)
+  require 'bundler/gem_tasks'
+end
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-require 'openstudio/extension/rake_task'
-require 'openstudio/extension'
-rake_task = OpenStudio::Extension::RakeTask.new
-rake_task.set_extension_class(OpenStudio::Extension::Extension, 'nrel/openstudio-extension-gem')
+# Only load extension tasks if we're not installing
+unless ARGV.include?('install')
+  require 'openstudio/extension/rake_task'
+  require 'openstudio/extension'
+  rake_task = OpenStudio::Extension::RakeTask.new
+  rake_task.set_extension_class(OpenStudio::Extension::Extension, 'nrel/openstudio-extension-gem')
+end
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new

--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 
-require 'bundler/setup'
+if !defined?(Bundler)
+  require 'bundler/setup'
+end
 require 'openstudio/extension'
 
 # You can add fixtures and/or initialization code here to make experimenting

--- a/init_templates/spec_helper.rb
+++ b/init_templates/spec_helper.rb
@@ -3,7 +3,9 @@
 # See also https://openstudio.net/license
 # *******************************************************************************
 
-require 'bundler/setup'
+if !defined?(Bundler)
+  require 'bundler/setup'
+end
 require 'openstudio/GEM_NAME_UNDERSCORES'
 
 RSpec.configure do |config|

--- a/lib/openstudio/extension/runner.rb
+++ b/lib/openstudio/extension/runner.rb
@@ -3,7 +3,10 @@
 # See also https://openstudio.net/license
 # *******************************************************************************
 
-require 'bundler'
+# Check if Bundler is already loaded
+if !defined?(Bundler)
+  require 'bundler'
+end
 require 'fileutils'
 require 'json'
 require 'open3'

--- a/lib/openstudio/extension/runner_config.rb
+++ b/lib/openstudio/extension/runner_config.rb
@@ -3,7 +3,10 @@
 # See also https://openstudio.net/license
 # *******************************************************************************
 
-require 'bundler'
+# Check if Bundler is already loaded
+if !defined?(Bundler)
+  require 'bundler'
+end
 require 'fileutils'
 require 'json'
 require 'parallel'

--- a/lib/openstudio/extension/version.rb
+++ b/lib/openstudio/extension/version.rb
@@ -5,6 +5,6 @@
 
 module OpenStudio
   module Extension
-    VERSION = '0.8.2'.freeze
+    VERSION = '0.8.3'.freeze
   end
 end

--- a/openstudio-extension.gemspec
+++ b/openstudio-extension.gemspec
@@ -34,8 +34,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'octokit', '~> 4.18.0' # for change logs
   spec.add_dependency 'openstudio_measure_tester', '~> 0.4.0'
   spec.add_dependency 'openstudio-workflow', '~> 2.4.0'
+  # parallel, regexp_parser, and addressable versions are pinned to avoid test_with_openstudio errors
   spec.add_dependency 'parallel', '~> 1.19.1'
   spec.add_dependency 'regexp_parser', '2.9.0'
+  spec.add_dependency 'addressable', '2.8.1'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,9 @@
 # See also https://openstudio.net/license
 # *******************************************************************************
 
-require 'bundler/setup'
+if !defined?(Bundler)
+  require 'bundler/setup'
+end
 require 'openstudio/extension'
 
 RSpec.configure do |config|


### PR DESCRIPTION
This PR is a cleaned up version of changes @wenyikuang figured out and made on the [ruby3-conditional_bundler](https://github.com/NREL/openstudio-extension-gem/tree/ruby3-conditional_bundler) branch. That branch was out of date and had some unnecessary commits, so I made this branch for a cleaner diff.

https://github.com/urbanopt/urbanopt-geojson-gem was spitting out an error when running `bundle exec rake openstudio:test_with_openstudio` that is documented here: https://github.com/NREL/OpenStudio/issues/5335