### PR TITLE
Bump version to 0.9.3 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # OpenStudio(R) Extension Gem
+
+## Version 0.9.3
+* Corrected the gemfile to remove rubocop-performance
+
 ## Version 0.9.2
 * Updating LICENSE.md in doc_templates to use 2025 for the year
 * Fixed some rubocop offenses

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,5 @@
 source 'http://rubygems.org'
 
-# Specify your gem's dependencies in openstudio-extension.# gemspec commented out to avoid circular dependency during bundle install
-# gemspec
-
 # Specify your gem's dependencies in openstudio-extension.gemspec
 
 # line below used for testing when need to test against branch instead of release of standards. Should be commented out prior to merge to develop
@@ -11,5 +8,3 @@ source 'http://rubygems.org'
 gemspec
 
 # gem 'openstudio-standards', '= 0.2.17.rc1', :github => 'NREL/openstudio-standards', :ref => '3.5.0_changes'
-
-gem 'rubocop-performance', '~> 1.20'

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ export RUBYLIB=/Applications/OpenStudio-3.1.0/Ruby
 
 |OpenStudio Extension Gem|OpenStudio|Ruby|
 |:--------------:|:----------:|:--------:|
+| 0.9.3          | 3.10     | 3.2.2  |
 | 0.9.2          | 3.10     | 3.2.2  |
 | 0.8.0          | 3.8      | 3.2    |
 | 0.7.1          | 3.7      | 2.7    |

--- a/lib/openstudio/extension/version.rb
+++ b/lib/openstudio/extension/version.rb
@@ -5,6 +5,6 @@
 
 module OpenStudio
   module Extension
-    VERSION = '0.9.2'.freeze
+    VERSION = '0.9.3'.freeze
   end
 end


### PR DESCRIPTION
Update the version number to 0.9.3, remove the rubocop-performance dependency from the Gemfile, and reflect these changes in the changelog.